### PR TITLE
Monkey patch s3boto storage to properly quote file names.

### DIFF
--- a/filer/storage.py
+++ b/filer/storage.py
@@ -1,5 +1,6 @@
 #-*- coding: utf-8 -*-
 from django.core.files.storage import FileSystemStorage
+from django.utils.encoding import filepath_to_uri
 
 
 class PublicFileSystemStorage(FileSystemStorage):
@@ -19,3 +20,23 @@ class PrivateFileSystemStorage(FileSystemStorage):
     See ``filer.settings`` for the defaults for ``location`` and ``base_url``.
     """
     is_secure = True
+
+
+try:
+    from storages.backends.s3boto import S3BotoStorage
+
+
+    class PatchedS3BotoStorage(S3BotoStorage):
+
+        def url(self, name):
+            name = filepath_to_uri(self._normalize_name(self._clean_name(name)))
+            if self.custom_domain:
+                return "%s://%s/%s" % ('https' if self.secure_urls else 'http',
+                                       self.custom_domain, name)
+            return self.connection.generate_url(self.querystring_expire,
+                method='GET', bucket=self.bucket.name, key=self._encode_name(name),
+                query_auth=self.querystring_auth, force_http=not self.secure_urls)
+
+
+except ImportError:
+    pass


### PR DESCRIPTION
This is a temporary solution until:
- django-storages issue #172 is fixed (http://code.larlet.fr/django-storages/issue/172/storageurl-should-quote-file-names-before#comment-4149177)
  OR
- pull req #70 is merged (http://code.larlet.fr/django-storages/pull-request/70/urlencode-paths-when-using/diff)
