### PR TITLE
LUN-1214: images without extension will be uploaded as filer images

### DIFF
--- a/filer/admin/clipboardadmin.py
+++ b/filer/admin/clipboardadmin.py
@@ -13,6 +13,8 @@ from filer.utils.files import (
 )
 from filer.views import popup_param, selectfolder_param, current_site_param
 from filer.admin.tools import is_valid_destination
+import imghdr
+import os
 
 # ModelAdmins
 class ClipboardItemInline(admin.TabularInline):
@@ -115,6 +117,15 @@ class ClipboardAdmin(admin.ModelAdmin):
         upload, file_obj = None ,None
         try:
             upload, filename, is_raw = handle_upload(request)
+
+            extension = os.path.splitext(filename)[1]
+            if not extension:
+                # try to guess if it's an image and append extension
+                # imghdr will detect file is a '.jpeg', '.png' or '.gif' image
+                guessed_extension = imghdr.what(upload)
+                if guessed_extension:
+                    filename = '%s.%s' % (filename, guessed_extension)
+
             # Get clipboad
             clipboard = Clipboard.objects.get_or_create(user=request.user)[0]
             if any(f for f in clipboard.files.all() if f.actual_name == filename):

--- a/filer/tests/admin.py
+++ b/filer/tests/admin.py
@@ -167,6 +167,22 @@ class FilerClipboardAdminUrlsTests(TestCase):
         for img in Image.objects.all():
             img.delete(to_trash=False)
 
+    def test_filer_upload_image_no_extension(self):
+        image = create_image()
+        image_path = os.path.join(os.path.dirname(__file__), 'image_name')
+        image.save(image_path, 'JPEG')
+        file_obj = dj_files.File(open(image_path))
+        self.assertEqual(Image.objects.count(), 0)
+        response = self.client.post(
+            reverse('admin:filer-ajax_upload'), {
+            'Filename': 'image_name',
+            'Filedata': file_obj,
+            'jsessionid': self.client.session.session_key, },
+        )
+        self.assertEqual(Image.objects.count(), 1)
+        self.assertEqual(Image.objects.all()[0].actual_name, 'image_name.jpeg')
+        os.remove(image_path)
+
     def test_filer_upload_file(self, extra_headers={}):
         self.assertEqual(Image.objects.count(), 0)
         file_obj = dj_files.File(open(self.filename))


### PR DESCRIPTION
- this will work for png, jpeg and gif
