### PR TITLE
LUN-3289: Rework permission checking to work with multiple managers.

### DIFF
--- a/filer/admin/fileadmin.py
+++ b/filer/admin/fileadmin.py
@@ -1,6 +1,4 @@
 #-*- coding: utf-8 -*-
-from django.core.urlresolvers import reverse
-from django.http import HttpResponseRedirect
 from django.db import models
 from django.utils.translation import ugettext  as _
 from filer.admin.common_admin import FilePermissionModelAdmin

--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -704,7 +704,8 @@ class FolderAdmin(FolderPermissionModelAdmin):
             get_permission_codename('delete', opts)
             p = '%s.%s' % (opts.app_label,
                            get_permission_codename('delete', opts))
-            if not user.has_perm(p):
+            # Also check permissions on individual objects
+            if not user.has_perm(p, obj) and not user.has_perm(p):
                 perms_needed.add(opts.verbose_name)
             # Display a link to the admin page.
             return mark_safe(u'%s: <a href="%s">%s</a>' %

--- a/filer/admin/patched/admin_utils.py
+++ b/filer/admin/patched/admin_utils.py
@@ -52,7 +52,8 @@ def get_deleted_objects(objs, opts, user, admin_site, using):
 
             p = '%s.%s' % (opts.app_label,
                            get_permission_codename('delete', opts))
-            if not user.has_perm(p):
+            # Additional change: also check for individual object permission
+            if not user.has_perm(p, obj) and not user.has_perm(p):
                 perms_needed.add(opts.verbose_name)
             # Display a link to the admin page.
             return format_html('{}: <a href="{}">{}</a>',

--- a/filer/models/filemodels.py
+++ b/filer/models/filemodels.py
@@ -634,15 +634,17 @@ class File(polymorphic.PolymorphicModel,
         return False
 
     def is_restricted_for_user(self, user):
+        perm = 'filer.can_restrict_operations'
         return (self.restricted and (
-                    not user.has_perm('filer.can_restrict_operations') or
-                    not can_restrict_on_site(user, self.folder.site)))
+            not (user.has_perm(perm, self) or user.has_perm(perm)) or
+            not can_restrict_on_site(user, self.folder.site)))
 
     def can_change_restricted(self, user):
         """
         Checks if restriction operation is available for this file.
         """
-        if not user.has_perm('filer.can_restrict_operations'):
+        perm = 'filer.can_restrict_operations'
+        if not user.has_perm(perm, self) and not user.has_perm(perm):
             return False
         if not self.folder:
             # cannot restrict unfiled files
@@ -671,32 +673,34 @@ class File(polymorphic.PolymorphicModel,
             # nobody can change core folder
             # leaving these on True based on the fact that core folders are
             # displayed as readonly fields
-             return True
+            return True
 
         # only admins can change site folders with no site owner
         if not self.folder.site and has_admin_role(user):
             return True
 
         if self.folder.site:
-            return (user.has_perm('filer.change_file') and
-                    has_role_on_site(user, self.folder.site))
+            can_change_file = (user.has_perm('filer.change_file', self) or
+                               user.has_perm('filer.change_file'))
+            return can_change_file and has_role_on_site(user, self.folder.site)
 
         return False
 
     def has_delete_permission(self, user):
         if not self.folder:
              # clipboard and unfiled files
-             return True
+            return True
         # nobody can delete core files
         if self.is_readonly_for_user(user):
-             return False
+            return False
         # only admins can delete site files with no site owner
         if not self.folder.site and has_admin_role(user):
-             return True
+            return True
 
         if self.folder.site:
-            return (user.has_perm('filer.delete_file') and
-                    has_role_on_site(user, self.folder.site))
+            can_delete_file = (user.has_perm('filer.delete_file', self) or
+                               user.has_perm('filer.delete_file'))
+            return can_delete_file and has_role_on_site(user, self.folder.site)
         return False
 
     class Meta:

--- a/filer/settings.py
+++ b/filer/settings.py
@@ -1,9 +1,11 @@
 #-*- coding: utf-8 -*-
+import os
+
 from django.conf import settings
 from django.core.files.storage import get_storage_class
+
 from filer.utils.loader import load_object
 from filer.utils.recursive_dictionary import RecursiveDictionaryWithExcludes
-import os
 
 
 FILER_DEBUG = getattr(settings, 'FILER_DEBUG', False) # When True makes
@@ -13,7 +15,7 @@ FILER_0_8_COMPATIBILITY_MODE = getattr(settings, 'FILER_0_8_COMPATIBILITY_MODE',
 
 FILER_ENABLE_LOGGING = getattr(settings, 'FILER_ENABLE_LOGGING', False)
 if FILER_ENABLE_LOGGING:
-    FILER_ENABLE_LOGGING = (FILER_ENABLE_LOGGING and (getattr(settings,'LOGGING') and
+    FILER_ENABLE_LOGGING = (FILER_ENABLE_LOGGING and (getattr(settings, 'LOGGING') and
                                                       ('' in settings.LOGGING['loggers'] or
                                                        'filer' in settings.LOGGING['loggers'])))
 
@@ -25,7 +27,7 @@ FILER_STATICMEDIA_PREFIX = getattr(settings, 'FILER_STATICMEDIA_PREFIX', None)
 if not FILER_STATICMEDIA_PREFIX:
     FILER_STATICMEDIA_PREFIX = (getattr(settings, 'STATIC_URL', None) or settings.MEDIA_URL) + 'filer/'
 
-FILER_ADMIN_ICON_SIZES = getattr(settings,"FILER_ADMIN_ICON_SIZES",('32',))
+FILER_ADMIN_ICON_SIZES = getattr(settings, "FILER_ADMIN_ICON_SIZES", ('32',))
 
 # This is an ordered iterable that describes a list of
 # classes that I should check for when adding files
@@ -221,3 +223,41 @@ CDN_INVALIDATION_TIME = getattr(settings, 'FILER_CDN_INVALIDATION_TIME', 0)
 FILER_TRASH_PREFIX = getattr(settings, 'FILER_TRASH_PREFIX', '_trash')
 # defaults to one day
 FILER_TRASH_CLEAN_INTERVAL = getattr(settings, 'FILER_TRASH_CLEAN_INTERVAL', 60 * 60 * 24)
+
+
+# Roles Manager that controles how the filer checks permissions
+# Must be a callable or a the absolute path of the callable as a string.
+# Calling this manager should return an object that must define these functions:
+#
+# def is_site_admin(user):
+#     """
+#     :param user: django.contrib.auth.models.User to check permissions for
+#     :return: True if the user is an admin on any site, False otherwise
+#     """
+#     pass
+
+# def has_perm_on_site(user, site_id, perm):
+#     """
+#     :param user: django.contrib.auth.models.User to check permissions for
+#     :param site_id: id of django.contrib.sites.models.Site
+#                     on which the user must have the permission
+#     :param perm: full name (<app_label>.<permission>) of the permission, ex: filer.add_file
+#     :return: True if the user has the permission on that site, False otherwise
+#     """
+#     pass
+
+# def get_accessible_sites(user):
+#     """
+#     :return: list of django.contrib.sites.models.Site IDs on which the user has access.
+#     """
+#     pass
+
+# def get_administered_sites(user):
+#     """
+#     :return: list of django.contrib.sites.models.Site objects on which the user has admin access.
+#     """
+#     pass
+
+FILER_ROLES_MANAGER = getattr(settings,
+                              'FILER_ROLES_MANAGER',
+                              'cmsroles.siteadmin.FilerRolesManager')

--- a/filer/south_migrations/0017_assign_sites_to_folders.py
+++ b/filer/south_migrations/0017_assign_sites_to_folders.py
@@ -8,14 +8,9 @@ from django.contrib.sites.models import Site
 from django.contrib.auth.models import Group, User
 from filer.utils.cms_roles import get_sites_for_user
 from filer.utils.checktrees import TreeChecker
-from cmsroles.models import Role
 
 
 class Migration(DataMigration):
-
-    depends_on = (
-        ("cmsroles", "0003_rename_site_group"),
-    )
 
     core_folders = ['media', '_bento_media']
     fallback_site = 'lunchbox.pbs.org'

--- a/filer/test_settings.py
+++ b/filer/test_settings.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 import os
+
 import filer
+
+
 DEBUG = True
 PACKAGE_ROOT = os.path.abspath(os.path.join(
     os.path.dirname(filer.__file__), '..'))
@@ -73,7 +76,7 @@ TEMPLATES = [
                 "django.template.context_processors.static",
             ),
             'loaders': (
-                'cmsroles.tests.utils.MockLoader',
+                'filer.tests.utils.MockLoader',
                 'django.template.loaders.filesystem.Loader',
                 'django.template.loaders.app_directories.Loader',
             ),
@@ -81,3 +84,23 @@ TEMPLATES = [
         },
     },
 ]
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'simple': {
+            'format': '%(levelname)s %(module)s %(message)s'
+        },
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'simple'
+        },
+    },
+    'root': {
+        'handlers': ['console', ],
+        'level': 'WARNING',
+    },
+}

--- a/filer/tests/utils.py
+++ b/filer/tests/utils.py
@@ -1,11 +1,13 @@
 #-*- coding: utf-8 -*-
+from zipfile import ZipFile
+import os
+
 from django.core.files import File as DjangoFile
 from django.test.testcases import TestCase
 from filer.tests.helpers import create_image
+
 from filer.utils.loader import load
 from filer.utils.zip import unzip
-from zipfile import ZipFile
-import os
 
 #===============================================================================
 # Some target classes for the classloading tests

--- a/filer/tests/utils/__init__.py
+++ b/filer/tests/utils/__init__.py
@@ -1,2 +1,19 @@
+from django.template.loaders.base import Loader as BaseLoader
+from django.template.base import TemplateDoesNotExist
+
+
 class Mock():
     pass
+
+
+class MockLoader(BaseLoader):
+
+    is_usable = True
+
+    def load_template_source(self, template_name, template_dirs=None):
+        if template_name == 'cms_mock_template.html':
+            return '<div></div>', 'template.html'
+        elif template_name == '404.html':
+            return "404 Not Found", "404.html"
+        else:
+            raise TemplateDoesNotExist()

--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,6 @@ def read(fname):
     # read the contents of a text file
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
-dependency_links = [
-    'http://github.com/pbs/django-cms-roles/tarball/master#egg=django-cms-roles-dev',
-]
-
 setup(
     name="django-filer",
     version=version,
@@ -34,11 +30,8 @@ setup(
         'easy-thumbnails<=2.2',
         'django-mptt==0.7.4',
         'django_polymorphic<=0.7.1',
-        'django-cms-roles>0.7.0.pbs,<0.7.0.pbs.1000',
-        'django-cms>=2.3.5pbs,<2.3.5pbs.1000',
         'requests==2.7.0',
     ),
-    dependency_links=dependency_links,
     include_package_data=True,
     zip_safe=False,
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,9 @@ install_command=
 deps=
     pytest-django
     Django>=1.8,<1.9a
+    django-cms-roles>0.7.0.pbs,<0.7.0.pbs.1000
+    django-cms>=2.3.5pbs,<2.3.5pbs.1000
+    django-mptt==0.7.4
 changedir=
     {envdir}
 commands=


### PR DESCRIPTION
The base assumption is that `user.has_perm(filer_perm) or user.has_perm(filer_perm, obj)` will work for all authorization backends.
Backends who do not support object level permissions should return false for object level permissions (django-cms-roles).
Backends who support object level permissions should decide when they want to return True for `user.has_perm(perm)` (bento3).
