### PR TITLE
Ben 1952 Attempting to copy more than one file in Filer returns Server Error (500)

### DIFF
--- a/filer/models/filemodels.py
+++ b/filer/models/filemodels.py
@@ -1,5 +1,11 @@
-
 #-*- coding: utf-8 -*-
+import polymorphic
+import hashlib
+import os
+import filer
+import logging
+import operator
+
 from django.contrib.auth import models as auth_models
 from django.core import urlresolvers
 from django.core.files.base import ContentFile
@@ -13,11 +19,7 @@ from filer.utils.files import matching_file_subtypes
 from filer import settings as filer_settings
 from django.db.models import Count
 from django.utils import timezone
-import polymorphic
-import hashlib
-import os
-import filer
-import logging
+
 
 logger = logging.getLogger(__name__)
 
@@ -508,7 +510,7 @@ class File(polymorphic.PolymorphicModel,
         return text
 
     def __lt__(self, other):
-        return cmp(self.label.lower(), other.label.lower()) < 0
+        return operator.lt(self.label.lower(), other.label.lower())
 
     @property
     def actual_name(self):

--- a/filer/models/filemodels.py
+++ b/filer/models/filemodels.py
@@ -566,7 +566,7 @@ class File(polymorphic.PolymorphicModel,
         full_path = '{}{}{}'.format(directory_path, os.sep, self.actual_name)
         return full_path
 
-    def __unicode__(self):
+    def __str__(self):
         try:
             name = self.pretty_logical_path
         except:

--- a/filer/models/foldermodels.py
+++ b/filer/models/foldermodels.py
@@ -489,7 +489,7 @@ class Folder(models.Model, mixins.IconsMixin):
         return urlresolvers.reverse('admin:filer-directory_listing',
                                     args=(self.id,))
 
-    def __unicode__(self):
+    def __str__(self):
         try:
             name = self.pretty_logical_path
         except:


### PR DESCRIPTION
At migration to python3, we needed to remove cmp occurences (replaced here with operator.lt)
Additionaly, for the file/folder names to show as names (not 'folder object') we need str instead of unicode