### PR TITLE
BEN-2235: Proxy all unknown method calls to the queryset

### DIFF
--- a/filer/models/filemodels.py
+++ b/filer/models/filemodels.py
@@ -73,6 +73,14 @@ class FileQuerySet(PolymorphicQuerySet):
 class FileManager(PolymorphicManager):
     queryset_class = FileQuerySet
 
+    # Proxy all unknown method calls to the queryset, so that its members are
+    # directly accessible as PolymorphicModel.objects.*
+    # Exclude any special functions (__) from this automatic proxying.
+    def __getattr__(self, name):
+        if name.startswith('__'):
+            return super(PolymorphicManager, self).__getattr__(self, name)
+        return getattr(self.all(), name)
+
     def find_all_duplicates(self):
         return {file_data['sha1']: file_data['count']
                 for file_data in self.get_queryset().values('sha1').annotate(


### PR DESCRIPTION
The `FileManager` relied on `django-polymorphic`'s default behavior of automatically proxying unknown method calls to the queryset. However, this default behavior [was removed in an update of `django-polymorphic`](https://github.com/django-polymorphic/django-polymorphic/commit/009069a32b3ff627a2b364c557b80accb9ab14c0) and thus breaking our custom Filer logic, because the method `find_duplicates` which is on the `FileQuerySet` class wasn't found anymore.

I wanted to keep the changes as small as possible and to have the least impact on the code, that's why I chose to restore the automatic proxying of unknown methods to the queryset. 