### PR TITLE
BEN-2247: set content type on file upload

### DIFF
--- a/filer/__init__.py
+++ b/filer/__init__.py
@@ -1,5 +1,5 @@
 #-*- coding: utf-8 -*-
 # version string following pep-0396 and pep-0386
-__version__ = '0.9pbs.106'  # pragma: nocover
+__version__ = '0.9pbs.107.dev1'  # pragma: nocover
 
 default_app_config = 'filer.apps.FilerConfig'

--- a/filer/storage.py
+++ b/filer/storage.py
@@ -2,6 +2,7 @@
 import logging
 import botocore.exceptions
 import urllib.parse
+import mimetypes
 
 from django.core.files.storage import FileSystemStorage
 from django.utils.encoding import smart_str
@@ -83,3 +84,7 @@ class PatchedS3BotoStorage(S3BotoStorage):
         if self.has_public_read(source_obj):
             extra_args['ACL'] = 'public-read'
         self.bucket.copy(copy_source, dst_path, extra_args)
+
+    def get_object_parameters(self, name):
+        mime_type = mimetypes.guess_type(name)[0] or "text/plain"
+        return {'ContentType': mime_type}

--- a/filer/storage.py
+++ b/filer/storage.py
@@ -2,7 +2,6 @@
 import logging
 import botocore.exceptions
 import urllib.parse
-import mimetypes
 
 from django.core.files.storage import FileSystemStorage
 from django.utils.encoding import smart_str
@@ -84,7 +83,3 @@ class PatchedS3BotoStorage(S3BotoStorage):
         if self.has_public_read(source_obj):
             extra_args['ACL'] = 'public-read'
         self.bucket.copy(copy_source, dst_path, extra_args)
-
-    def get_object_parameters(self, name):
-        mime_type = mimetypes.guess_type(name)[0] or "text/plain"
-        return {'ContentType': mime_type}

--- a/filer/utils/files.py
+++ b/filer/utils/files.py
@@ -1,8 +1,11 @@
 #-*- coding: utf-8 -*-
 import os
+import mimetypes
+
 from django.utils.text import get_valid_filename as get_valid_filename_django
 from django.template.defaultfilters import slugify
 from django.core.files.uploadedfile import SimpleUploadedFile
+
 from filer.settings import FILER_FILE_MODELS
 from filer.utils.loader import load_object
 
@@ -29,7 +32,8 @@ def handle_upload(request):
             data = request.raw_post_data
         else:
             raise UploadException("Request is not valid: there is no request body.")
-        upload = SimpleUploadedFile(name=filename, content=data)
+        mime_type = mimetypes.guess_type(filename)[0] or "text/plain"
+        upload = SimpleUploadedFile(name=filename, content=data, content_type=mime_type)
     else:
         if len(request.FILES) == 1:
             # FILES is a dictionary in Django but Ajax Upload gives the uploaded file an


### PR DESCRIPTION
This pull-request fixes the issue of all uploaded files having the `content-type: "text/plain"`.

This happened after we switched to a newer `django-storages` package (1.4.1 -> 1.9.1) as part of our Django 2.2 upgrade.
The flow is as follows:
1. User uploads a file in Filer;
2. Django sets by default `content-type: "text/plain"`;
3. `django-storages` uploads the file to S3;
    * [`django-storages` 1.4.1 tried to guess the content-type and set it before uploading to S3;](https://github.com/jschneier/django-storages/blob/1.4.1/storages/backends/s3boto.py#L144)
    * `django-storages` 1.9.1, the version we're currently using, only tries to guess the content type if the file doesn't already have one set. Since Filer doesn't set any content type and [Django adds by default `plain/text`](https://github.com/django/django/blob/0b79eb36915d178aef5c6a7bbce71b1e76d376d3/django/core/files/uploadedfile.py#L106),  [django-storages doesn't try to update it](https://github.com/jschneier/django-storages/blob/1.9.1/storages/backends/s3boto3.py#L606).