### PR TITLE
BEN-2476 error when copying a renamed file

### DIFF
--- a/filer/__init__.py
+++ b/filer/__init__.py
@@ -1,5 +1,5 @@
 #-*- coding: utf-8 -*-
 # version string following pep-0396 and pep-0386
-__version__ = '0.9pbs.109.dev1'  # pragma: nocover
+__version__ = '0.9pbs.109'  # pragma: nocover
 
 default_app_config = 'filer.apps.FilerConfig'

--- a/filer/__init__.py
+++ b/filer/__init__.py
@@ -1,5 +1,5 @@
 #-*- coding: utf-8 -*-
 # version string following pep-0396 and pep-0386
-__version__ = '0.9pbs.108'  # pragma: nocover
+__version__ = '0.9pbs.109.dev1'  # pragma: nocover
 
 default_app_config = 'filer.apps.FilerConfig'

--- a/filer/models/filemodels.py
+++ b/filer/models/filemodels.py
@@ -266,7 +266,7 @@ class File(PolymorphicModel,
                                        ContentFile(src_file.read()))
             src_file.close()
         self._current_file_location = destination
-        self.old_name = self.name
+        self._old_name = self.name
         self._old_folder_id = getattr(self.folder, 'id', None)
         return destination
 


### PR DESCRIPTION
in the `_copy_file` method, after the actual file is copied in storage in the new path, the old_name is not properly reset, so the method `_is_path_changed` will again try to copy the file in storage, when File obj is saved.