### PR TITLE
get rid of the custom 'pbs' version notation ...

### DIFF
--- a/filer/__init__.py
+++ b/filer/__init__.py
@@ -1,5 +1,5 @@
-#-*- coding: utf-8 -*-
-# version string following pep-0396 and pep-0386
-__version__ = '0.9pbs.111'  # pragma: nocover
+# -*- coding: utf-8 -*-
+# version string following pep-0440
+__version__ = '0.9.111'  # pragma: nocover
 
 default_app_config = 'filer.apps.FilerConfig'


### PR DESCRIPTION
… , because new versions of pip doesn't support this notation anymore. (pip>20.3)